### PR TITLE
メモ、振り返りメモの文字数制限を変更

### DIFF
--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -6,7 +6,7 @@ class Memo < ApplicationRecord
   has_many :reflection_memo_memos
   has_many :reflection_memos, through: :reflection_memo_memos
 
-  validates :content, presence: true, length: { maximum: 5 }
+  validates :content, presence: true, length: { maximum: 225 }
 
   def self.ransackable_attributes(auth_object = nil)
     ["content", "created_at", "progress"]

--- a/app/models/reflection_memo.rb
+++ b/app/models/reflection_memo.rb
@@ -3,7 +3,7 @@ class ReflectionMemo < ApplicationRecord
   has_many :reflection_memo_memos
   has_many :memos, through: :reflection_memo_memos
 
-  validates :content, presence: true, length: { maximum: 5 }
+  validates :content, presence: true, length: { maximum: 225 }
   after_save :update_memo_progress
 
   def self.ransackable_attributes(auth_object = nil)


### PR DESCRIPTION
## 関連issue
Closes #95 

## 概要
<!--このPull Requestの目的を簡潔に説明してください。-->
- メモ、振り返りメモの文字数制限を5文字から225文字に変更する

## 実装内容
- 変更点1<br>
memoモデルのcontentのlengthバリデーションを5→225に修正

- 変更点2<br>
reflection_memoモデルのcontentのlengthバリデーションを5→225に修正

## 備考
[![Image from Gyazo](https://t.gyazo.com/teams/startup-technology/bafeebe96ba73df10e59d963250f7f3a.gif)](https://startup-technology.gyazo.com/bafeebe96ba73df10e59d963250f7f3a)

[![Image from Gyazo](https://t.gyazo.com/teams/startup-technology/b3d13b8ce8596304974a0f1b12865ad0.gif)](https://startup-technology.gyazo.com/b3d13b8ce8596304974a0f1b12865ad0)



