### PR TITLE
line_user_id_create

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -12,5 +12,5 @@ Rails.application.config.sorcery.configure do |config|
   config.line.secret = Rails.application.credentials.dig(:line, :channel_secret) 
   config.line.callback_url = Rails.application.credentials.dig(Rails.env, :line, :callback_url)
   config.line.scope = 'profile'
-  config.line.user_info_mapping = { username: 'displayName', email: 'userId' }
+  config.line.user_info_mapping = { username: 'displayName', email: ->(response) { "#{response['userId']}@test.com" }, line_user_id: 'userId' }
 end


### PR DESCRIPTION
## 関連issue
yu-ka3028/Shibatt#355

## 概要
<!--このPull Requestの目的を簡潔に説明してください。-->
- line_user_idを保存できるようにする

## 実装内容
- 変更点1<br>
  - 前：line_use_loginをUserテーブルに保存する
  - 後：liffでのログインは可能であり、LINEログインと2つの扱いが被るためLINEログインは無しにする

## 備考
